### PR TITLE
bug-fix: Restrict notification sound to dashboard & block back navigation post-logout

### DIFF
--- a/.idea/other.xml
+++ b/.idea/other.xml
@@ -26,6 +26,17 @@
           <option name="screenY" value="2160" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="Lenovo" />
+          <option name="codename" value="TB370FU" />
+          <option name="id" value="TB370FU" />
+          <option name="manufacturer" value="Lenovo" />
+          <option name="name" value="Tab P12" />
+          <option name="screenDensity" value="340" />
+          <option name="screenX" value="1840" />
+          <option name="screenY" value="2944" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
           <option name="api" value="31" />
           <option name="brand" value="samsung" />
           <option name="codename" value="a51" />

--- a/app/src/main/java/com/example/istalumniapp/MainActivity.kt
+++ b/app/src/main/java/com/example/istalumniapp/MainActivity.kt
@@ -59,7 +59,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.onPrimary
                 ) {
-                    notificationViewModel.fetchNotifications()
+//                    notificationViewModel.fetchNotifications()
                     // Initialize the NavController
                     navController = rememberNavController()
                     // Calling the NavGraph that contains the composable with screens

--- a/app/src/main/java/com/example/istalumniapp/screen/DisplayAlumniJobsScreen.kt
+++ b/app/src/main/java/com/example/istalumniapp/screen/DisplayAlumniJobsScreen.kt
@@ -101,7 +101,9 @@ fun DisplayAlumniJobsScreen(
         LogoutConfirm(
             onConfirm = {
                 FirebaseAuth.getInstance().signOut() // Log out the user
-                navController.navigate(Screens.ISTLoginScreen.route) // Navigate to login screen
+                navController.navigate(Screens.ISTPreviewScreen.route) {
+                    popUpTo(0)
+                }
                 showLogoutConfirmation = false
             },
             onDismiss = { showLogoutConfirmation = false }
@@ -114,7 +116,8 @@ fun DisplayAlumniJobsScreen(
                 navController = navController,
                 userRole = "alumni", // Fixed as alumni
                 profilePhotoUrl = profilePhotoUrl,
-                onLogoutClick = {showLogoutConfirmation = true}
+                onLogoutClick = {showLogoutConfirmation = true},
+                notificationViewModel = notificationViewModel
             )
         },
         bottomBar = {

--- a/app/src/main/java/com/example/istalumniapp/screen/DisplayApplicationScreen.kt
+++ b/app/src/main/java/com/example/istalumniapp/screen/DisplayApplicationScreen.kt
@@ -92,7 +92,9 @@ fun DisplayApplicationScreen(
         LogoutConfirm(
             onConfirm = {
                 FirebaseAuth.getInstance().signOut() // Log out the user
-                navController.navigate(Screens.ISTLoginScreen.route) // Navigate to login screen
+                navController.navigate(Screens.ISTPreviewScreen.route) {
+                    popUpTo(0)
+                }
                 showLogoutConfirmation = false
             },
             onDismiss = { showLogoutConfirmation = false }
@@ -105,7 +107,8 @@ fun DisplayApplicationScreen(
                 navController = navController,
                 onLogoutClick = { showLogoutConfirmation = true },
                 userRole = userRole,
-                profilePhotoUrl = profilePhotoUrl
+                profilePhotoUrl = profilePhotoUrl,
+                notificationViewModel = notificationViewModel
             )
         },
         bottomBar = {

--- a/app/src/main/java/com/example/istalumniapp/screen/DisplayJobScreen.kt
+++ b/app/src/main/java/com/example/istalumniapp/screen/DisplayJobScreen.kt
@@ -98,7 +98,9 @@ fun DisplayJobScreen(
         LogoutConfirm(
             onConfirm = {
                 FirebaseAuth.getInstance().signOut() // Log out the user
-                navController.navigate(Screens.ISTLoginScreen.route) // Navigate to login screen
+                navController.navigate(Screens.ISTPreviewScreen.route) {
+                    popUpTo(0)
+                }
                 showLogoutConfirmation = false
             },
             onDismiss = { showLogoutConfirmation = false }
@@ -111,7 +113,8 @@ fun DisplayJobScreen(
                 navController = navController,
                 onLogoutClick = { showLogoutConfirmation = true },
                 userRole = userRole,
-                profilePhotoUrl = profilePhotoUrl
+                profilePhotoUrl = profilePhotoUrl,
+                notificationViewModel = notificationViewModel
             )
         },
         bottomBar = {
@@ -294,7 +297,7 @@ fun JobItem(
                     horizontalArrangement = Arrangement.SpaceBetween
                 ) {
                     Button(onClick = { navController.navigate("edit_job/${job.jobID}") }) {
-                        Icon(imageVector = Icons.Default.Edit, contentDescription = "Delete Job")
+                        Icon(imageVector = Icons.Default.Edit, contentDescription = "Edit Job")
                     }
                     IconButton(onClick = { showDeleteConfirmation = true }) {
                         Icon(imageVector = Icons.Default.Delete, contentDescription = "Delete Job")

--- a/app/src/main/java/com/example/istalumniapp/screen/NotificationScreen.kt
+++ b/app/src/main/java/com/example/istalumniapp/screen/NotificationScreen.kt
@@ -64,8 +64,6 @@ fun NotificationScreen(
             )
         }
 
-        // Simulate fetching notifications
-        notificationViewModel.fetchNotifications()
         isLoading = false // Set loading to false after fetching
     }
 
@@ -74,7 +72,9 @@ fun NotificationScreen(
         LogoutConfirm(
             onConfirm = {
                 FirebaseAuth.getInstance().signOut() // Log out the user
-                navController.navigate(Screens.ISTLoginScreen.route) // Navigate to login screen
+                navController.navigate(Screens.ISTPreviewScreen.route) {
+                    popUpTo(0)
+                }
                 showLogoutConfirmation = false
             },
             onDismiss = { showLogoutConfirmation = false }
@@ -87,7 +87,9 @@ fun NotificationScreen(
                 navController = navController,
                 onLogoutClick = { showLogoutConfirmation = true },
                 userRole = userRole,
-                profilePhotoUrl = profilePhotoUrl
+                profilePhotoUrl = profilePhotoUrl,
+                notificationViewModel = notificationViewModel
+
             )
         },
         bottomBar = {

--- a/app/src/main/java/com/example/istalumniapp/screen/VIewApplicationsScreen.kt
+++ b/app/src/main/java/com/example/istalumniapp/screen/VIewApplicationsScreen.kt
@@ -80,7 +80,9 @@ fun ViewApplicationScreen(
                 navController = navController,
                 onLogoutClick = { showLogoutConfirmation = true },
                 userRole = userRole,
-                profilePhotoUrl = profilePhotoUrl
+                profilePhotoUrl = profilePhotoUrl,
+                notificationViewModel = notificationViewModel
+
             )
         },
         bottomBar = {

--- a/app/src/main/java/com/example/istalumniapp/screen/ViewAlumniProfilesScreen.kt
+++ b/app/src/main/java/com/example/istalumniapp/screen/ViewAlumniProfilesScreen.kt
@@ -76,7 +76,9 @@ fun ViewAlumniProfilesScreen(
         LogoutConfirm(
             onConfirm = {
                 FirebaseAuth.getInstance().signOut() // Log out the user
-                navController.navigate(Screens.ISTLoginScreen.route) // Navigate to login screen
+                navController.navigate(Screens.ISTPreviewScreen.route) {
+                    popUpTo(0)
+                }
                 showLogoutConfirmation = false
             },
             onDismiss = { showLogoutConfirmation = false }
@@ -90,7 +92,9 @@ fun ViewAlumniProfilesScreen(
                 navController = navController,
                 onLogoutClick = { showLogoutConfirmation = true },
                 userRole = userRole,
-                profilePhotoUrl = profilePhotoUrl
+                profilePhotoUrl = profilePhotoUrl,
+                notificationViewModel = notificationViewModel
+
             )
         },
         bottomBar = {

--- a/app/src/main/java/com/example/istalumniapp/screen/ViewProfileScreen.kt
+++ b/app/src/main/java/com/example/istalumniapp/screen/ViewProfileScreen.kt
@@ -83,7 +83,7 @@ fun ViewProfileScreen(navController: NavController, profileViewModel: ProfileVie
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(20.dp)
+            .padding(20.dp, top = 30.dp)
     ) {
         // Add back button
         IconButton(onClick = { navController.popBackStack() }) {

--- a/app/src/main/java/com/example/istalumniapp/utils/ProfileViewModel.kt
+++ b/app/src/main/java/com/example/istalumniapp/utils/ProfileViewModel.kt
@@ -26,6 +26,7 @@ import com.example.istalumniapp.R
 import kotlinx.coroutines.CoroutineScope
 import okhttp3.internal.notify
 import android.app.NotificationManager
+import androidx.compose.ui.platform.LocalContext
 
 
 @Suppress("UNCHECKED_CAST")
@@ -191,6 +192,7 @@ class ProfileViewModel :ViewModel()  {
             }
             return@launch
         }
+
 
         // Use the current user's uid as the profileID
         val profileID = uid


### PR DESCRIPTION
This pull request addresses two critical bug fixes:

Notification Sound Behavior:
Ensured the notification sound only plays when the user is on the dashboard screen. This prevents the sound from being triggered in other parts of the app.

Logout Navigation Issue:
Resolved the bug where users could navigate back to a previous screen after logging out. After logout, back navigation is now blocked, ensuring proper session termination.

Changes Made:
Added logic to check if the user is on the dashboard screen before playing the notification sound.
Fixed logout behavior to prevent users from navigating back to a prior screen after logging out.

Testing:
Verified notification sound behavior is limited to the dashboard screen.
Tested logout flow to ensure back navigation is disabled post-logout across various screens.